### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# http://editorconfig.org/
+
+[*.{pl,pm,t,pod}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,5 +3,5 @@
 [*.{pl,pm,t,pod}]
 end_of_line = lf
 indent_style = space
-indent_size = 4
+indent_size = 2
 insert_final_newline = true


### PR DESCRIPTION
Hey, I think it will be useful to have same type of indentation in snippets to keep them readable, hence I suggest editorconfig as an editor-independent solution. Currently, Moo example is indented with 2 spaces and Object::Pad example is indented with 3 spaces. I suggest 4 spaces, but its easily configurable. After merging, indentation in existing snippets would need to be adjusted by hand.